### PR TITLE
Verify account storage root on create client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         run: |
           make set-port
           make contracts
+        env:
+          PREIMAGE_MAKER: ./
       - name: Start preimage server
         run: |
           cd optimism-preimage-maker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,17 @@ jobs:
           sudo apt install kurtosis-cli=1.15.2 -V
       - name: Download optimism-preimage-maker
         run: |
-          git clone -b v0.3.2 https://github.com/datachainlab/optimism-preimage-maker
+          git clone -b v0.3.3 https://github.com/datachainlab/optimism-preimage-maker
       - name: Start optimism dev net
         run: |
           cd optimism-preimage-maker
           make chain
           make devnet-up
           make set-port
+      - name: Deploy contracts
+        run: |
+          make set-port
+          make contracts
       - name: Start preimage server
         run: |
           cd optimism-preimage-maker
@@ -60,8 +64,6 @@ jobs:
           sudo rm -rf $HOME/.cache
       - name: Test
         run: |
-          make set-port
-          make contracts
           sleep 180
           go test ./module/...
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
           cd optimism-preimage-maker
           make server-up &
           make wait
-          sleep 180
       - name: Clean up cache
         run: |
           sudo rm -rf $HOME/.cargo/registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           cd optimism-preimage-maker
           make server-up &
           make wait
+          sleep 180
       - name: Clean up cache
         run: |
           sudo rm -rf $HOME/.cargo/registry

--- a/module/prover/prover.go
+++ b/module/prover/prover.go
@@ -227,6 +227,18 @@ func (pr *Prover) CheckRefreshRequired(ctx context.Context, counterparty core.Ch
 }
 
 func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height exported.Height) (exported.ClientState, exported.ConsensusState, error) {
+	clientState, consState, err := pr.createInitialLightClientState(ctx, height)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Verify account storage root is not empty or zero
+	if err = util.VerifyStorageRootNotEmpty(consState.(*types.ConsensusState).StorageRoot); err != nil {
+		return nil, nil, errors.Wrapf(err, "invalid account storage root: number=%d: Wait until the finalized header reaches the height at which the contract was deployed.", clientState.GetLatestHeight().GetRevisionHeight())
+	}
+	return clientState, consState, nil
+}
+
+func (pr *Prover) createInitialLightClientState(ctx context.Context, height exported.Height) (exported.ClientState, exported.ConsensusState, error) {
 	var l2Output *l2.OutputResponse
 	var err error
 	if height != nil {

--- a/module/prover/prover_test.go
+++ b/module/prover/prover_test.go
@@ -63,7 +63,7 @@ func (ts *ProverTestSuite) SetupTest() {
 	ts.Require().NoError(err)
 	l2Chain, err := ethereum.NewChain(context.Background(), ethereum.ChainConfig{
 		RpcAddr:    fmt.Sprintf("http://localhost:%d", hostPort.L2GethPort),
-		IbcAddress: common.Bytes2Hex(addressHex),
+		IbcAddress: string(addressHex),
 		Signer:     anySignerConfig,
 	})
 	ts.Require().NoError(err)
@@ -282,7 +282,7 @@ func (ts *ProverTestSuite) TestMakeHeaderChan() {
 // testdata for ELC
 func (ts *ProverTestSuite) outputForELCUpdateClientTest(coreHeader core.Header) {
 	header := coreHeader.(*types.Header)
-	cs, consState, err := ts.prover.CreateInitialLightClientState(context.Background(), header.TrustedHeight)
+	cs, consState, err := ts.prover.createInitialLightClientState(context.Background(), header.TrustedHeight)
 	ts.Require().NoError(err)
 	rawUpdateClient, err := clienttypes.PackClientMessage(header)
 	ts.Require().NoError(err)
@@ -338,7 +338,7 @@ func (ts *ProverTestSuite) outputForELCUpdateClientTest(coreHeader core.Header) 
 
 func (ts *ProverTestSuite) outputForELCL1VerificationTest(headers []core.Header) {
 	first := headers[0].(*types.Header)
-	cs, consState, err := ts.prover.CreateInitialLightClientState(context.Background(), first.TrustedHeight)
+	cs, consState, err := ts.prover.createInitialLightClientState(context.Background(), first.TrustedHeight)
 	ts.Require().NoError(err)
 	rawCs := cs.(*types.ClientState)
 	rawL1Config, err := rawCs.L1Config.Marshal()

--- a/module/util/proof.go
+++ b/module/util/proof.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/errors"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// EmptyTrieRoot is keccak256 of RLP encoded empty bytes (0x80)
+// This represents the root hash of an empty Merkle Patricia Trie
+var EmptyTrieRoot = crypto.Keccak256(mustRLPEncodeEmptyBytes())
+
+func mustRLPEncodeEmptyBytes() []byte {
+	encoded, err := rlp.EncodeToBytes([]byte{})
+	if err != nil {
+		panic(err)
+	}
+	return encoded
+}
+
+// VerifyStorageRootNotEmpty verifies that the account storage root is not empty or zero.
+// Empty storage root (keccak256 of empty trie) indicates the account has no storage.
+func VerifyStorageRootNotEmpty(storageRoot []byte) error {
+	if len(storageRoot) == 0 {
+		return errors.New("account storage root is empty")
+	}
+
+	// Check for zero hash
+	zeroHash := make([]byte, len(storageRoot))
+	if bytes.Equal(storageRoot, zeroHash) {
+		return errors.New("account storage root is zero")
+	}
+
+	// Check for empty trie root (keccak256 of RLP encoded empty bytes)
+	if bytes.Equal(storageRoot, EmptyTrieRoot) {
+		return errors.New("account storage root is empty trie root (account has no storage)")
+	}
+
+	return nil
+}

--- a/module/util/proof_test.go
+++ b/module/util/proof_test.go
@@ -1,0 +1,66 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmptyTrieRoot(t *testing.T) {
+	// Empty trie root should be keccak256(0x80)
+	// 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
+	expected := common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+	require.Equal(t, expected[:], EmptyTrieRoot)
+}
+
+func TestVerifyStorageRootNotEmpty(t *testing.T) {
+	tests := []struct {
+		name        string
+		storageRoot []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "empty slice",
+			storageRoot: []byte{},
+			wantErr:     true,
+			errContains: "empty",
+		},
+		{
+			name:        "nil",
+			storageRoot: nil,
+			wantErr:     true,
+			errContains: "empty",
+		},
+		{
+			name:        "zero hash",
+			storageRoot: make([]byte, 32),
+			wantErr:     true,
+			errContains: "zero",
+		},
+		{
+			name:        "empty trie root",
+			storageRoot: EmptyTrieRoot,
+			wantErr:     true,
+			errContains: "empty trie root",
+		},
+		{
+			name:        "valid storage root",
+			storageRoot: common.HexToHash("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef").Bytes(),
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := VerifyStorageRootNotEmpty(tt.storageRoot)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary                                                                                                                                                              
                                                                                                                                                                       
  - Add validation to verify that the IBC contract's account storage root is not empty when creating the initial light client state                                    
  - This prevents creating a light client at a block height before the IBC contract was deployed                                                                       
                                                                                                                                                                       
  Changes                                                                                                                                                              
                                                                                                                                                                       
  - Add VerifyStorageRootNotEmpty function in util/proof.go that checks:                                                                                               
    - Storage root is not empty (zero length)                                                                                                                          
    - Storage root is not zero hash                                                                                                                                    
    - Storage root is not empty trie root (keccak256(rlp([])))                                                                                                         
  - Validate storage root in CreateInitialLightClientState before returning                                                                                            
  - Add unit tests for VerifyStorageRootNotEmpty                                                                                                                       
                                                                                                                                                                       
  Motivation                                                                                                                                                           
                                                                                                                                                                       
  If a user attempts to create a light client at a block height before the IBC contract was deployed, the account storage root will be empty (empty trie root). This   
  would result in an invalid light client state. By validating the storage root early, we provide a clear error message instructing the user to wait until the         
  finalized header reaches the deployment height.                                                                                                                      
                 